### PR TITLE
Skipping of rerun for tests marked with known bug

### DIFF
--- a/src/main/java/com/qaprosoft/zafira/client/BasicClient.java
+++ b/src/main/java/com/qaprosoft/zafira/client/BasicClient.java
@@ -74,6 +74,8 @@ public interface BasicClient {
     HttpClient.Response<TestType> createTestWorkItems(long testId, List<String> workItems);
 
     HttpClient.Response<WorkItem> createOrUpdateTestWorkItem(long testId, WorkItem workItem);
+    
+    HttpClient.Response<WorkItem[]> getTestWorkItems(long testId, WorkItem.Type type);
 
     /**
      * Attaches test artifact like logs or demo URLs.

--- a/src/main/java/com/qaprosoft/zafira/client/Path.java
+++ b/src/main/java/com/qaprosoft/zafira/client/Path.java
@@ -29,6 +29,7 @@ public enum Path {
     TEST_BY_ID_PATH("/api/tests/%d"),
     TEST_WORK_ITEMS_PATH("/api/tests/%d/workitems"),
     TEST_WORK_ITEM_PATH("/api/tests/%d/workitem"),
+    TEST_WORK_ITEM_BY_TYPE_PATH("/api/tests/%d/workitem/%s"),
     TEST_ARTIFACTS_PATH("/api/tests/%d/artifacts"),
     TEST_SUITES_PATH("/api/tests/suites"),
     TEST_CASES_PATH("/api/tests/cases"),

--- a/src/main/java/com/qaprosoft/zafira/client/impl/BasicClientImpl.java
+++ b/src/main/java/com/qaprosoft/zafira/client/impl/BasicClientImpl.java
@@ -369,7 +369,7 @@ public class BasicClientImpl implements BasicClient {
     public String getAuthToken() {
         return authToken;
     }
-    
+
     private CompletableFuture<TenantType> initTenant() {
         this.tenantType = CompletableFuture.supplyAsync(() -> getTenant().getObject());
         return tenantType;

--- a/src/main/java/com/qaprosoft/zafira/client/impl/BasicClientImpl.java
+++ b/src/main/java/com/qaprosoft/zafira/client/impl/BasicClientImpl.java
@@ -65,6 +65,7 @@ public class BasicClientImpl implements BasicClient {
     private static final String ERR_MSG_DELETE_TEST = "Unable to delete test";
     private static final String ERR_MSG_CREATE_TEST_WORK_ITEMS = "Unable to create test work items";
     private static final String ERR_MSG_CREATE_TEST_WORK_ITEM = "Unable to create test work item";
+    private static final String ERR_MSG_GET_TEST_WORK_ITEMS = "Unable to get test work items";
     private static final String ERR_MSG_ADD_TEST_ARTIFACT = "Unable to add test artifact";
     private static final String ERR_MSG_CREATE_TEST_CASE = "Unable to create test case";
     private static final String ERR_MSG_CREATE_TEST_CASES_BATCH = "Unable to create test cases";
@@ -248,6 +249,14 @@ public class BasicClientImpl implements BasicClient {
     }
 
     @Override
+    public HttpClient.Response<WorkItem[]> getTestWorkItems(long testId, WorkItem.Type type) {
+        return HttpClient.uri(Path.TEST_WORK_ITEM_BY_TYPE_PATH, serviceURL, testId, type.toString())
+                         .withAuthorization(authToken, project)
+                         .onFailure(ERR_MSG_GET_TEST_WORK_ITEMS)
+                         .get(WorkItem[].class);
+    }
+    
+    @Override
     public void addTestArtifact(TestArtifactType artifact) {
         HttpClient.uri(Path.TEST_ARTIFACTS_PATH, serviceURL, artifact.getTestId())
                   .withAuthorization(authToken, project)
@@ -360,7 +369,7 @@ public class BasicClientImpl implements BasicClient {
     public String getAuthToken() {
         return authToken;
     }
-
+    
     private CompletableFuture<TenantType> initTenant() {
         this.tenantType = CompletableFuture.supplyAsync(() -> getTenant().getObject());
         return tenantType;

--- a/src/main/java/com/qaprosoft/zafira/client/impl/ZafiraClientImpl.java
+++ b/src/main/java/com/qaprosoft/zafira/client/impl/ZafiraClientImpl.java
@@ -28,6 +28,7 @@ import com.qaprosoft.zafira.config.CiConfig;
 import com.qaprosoft.zafira.models.db.Initiator;
 import com.qaprosoft.zafira.models.db.Status;
 import com.qaprosoft.zafira.models.db.workitem.WorkItem;
+import com.qaprosoft.zafira.models.db.workitem.WorkItem.Type;
 import com.qaprosoft.zafira.models.dto.JobType;
 import com.qaprosoft.zafira.models.dto.ProjectType;
 import com.qaprosoft.zafira.models.dto.TagType;
@@ -41,6 +42,7 @@ import com.qaprosoft.zafira.models.dto.auth.AuthTokenType;
 import com.qaprosoft.zafira.models.dto.auth.TenantType;
 import com.qaprosoft.zafira.models.dto.user.UserType;
 import com.qaprosoft.zafira.util.http.HttpClient;
+import com.qaprosoft.zafira.util.http.HttpClient.Response;
 
 public class ZafiraClientImpl implements ZafiraClient {
 
@@ -152,6 +154,11 @@ public class ZafiraClientImpl implements ZafiraClient {
     @Override
     public HttpClient.Response<WorkItem> createOrUpdateTestWorkItem(long testId, WorkItem workItem) {
         return basicClient.createOrUpdateTestWorkItem(testId, workItem);
+    }
+    
+    @Override
+    public HttpClient.Response<WorkItem[]> getTestWorkItems(long testId, WorkItem.Type type) {
+        return basicClient.getTestWorkItems(testId, type);
     }
 
     @Override

--- a/src/main/java/com/qaprosoft/zafira/listener/ZafiraEventRegistrar.java
+++ b/src/main/java/com/qaprosoft/zafira/listener/ZafiraEventRegistrar.java
@@ -108,6 +108,8 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
     private static TestRunType run;
     private Map<String, TestType> registeredTests = new HashMap<>();
     private Set<String> classesToRerun = new HashSet<>();
+    
+    private Set<String> testsWithKnownIssues = new HashSet<>();
 
     private static ThreadLocal<String> threadCiTestId = new ThreadLocal<>();
     private static ThreadLocal<TestType> threadTest = new ThreadLocal<>();
@@ -236,6 +238,10 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
             String testName = configurator.getTestName(adapter);
 
             TestCaseType testCase = registerTestCase(adapter);
+            
+            if(testsWithKnownIssues.contains(testName)) {
+            	throw adapter.getSkipExceptionInstance("ALREADY_FAILED_BY_KNOWN_BUG: " + testName);
+            }
 
             // Search already registered test!
             if (registeredTests.containsKey(testName)) {
@@ -315,6 +321,12 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
         // Test is skipped as ALREADY_PASSED
         if (adapter.getThrowable() != null && adapter.getThrowable().getMessage() != null
                 && adapter.getThrowable().getMessage().startsWith("ALREADY_PASSED")) {
+            return;
+        }
+
+        // Test is skipped as ALREADY_FAILED_BY_KNOWN_BUG
+        if (adapter.getThrowable() != null && adapter.getThrowable().getMessage() != null
+                && adapter.getThrowable().getMessage().startsWith("ALREADY_FAILED_BY_KNOWN_BUG")) {
             return;
         }
 
@@ -585,6 +597,10 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
         testTypeService.finishTest(finishedTest);
 
         if (FAILED.equals(status) || SKIPPED.equals(status)) {
+            List<WorkItem> knownIssues = testTypeService.getKnownIssues(finishedTest.getId());
+            if (!knownIssues.isEmpty()) {
+                testsWithKnownIssues.add(finishedTest.getName());
+            }
             registerKnownIssue(adapter, finishedTest.getId(), finishedTest.getTestCaseId());
         }
     }

--- a/src/main/java/com/qaprosoft/zafira/listener/ZafiraEventRegistrar.java
+++ b/src/main/java/com/qaprosoft/zafira/listener/ZafiraEventRegistrar.java
@@ -89,6 +89,9 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
 
     private static final String ZAFIRA_RUN_ID_PARAM = "zafira_run_id";
 
+    private static final String ALREADY_PASSED = "ALREADY_PASSED";
+    private static final String ALREADY_FAILED_BY_KNOWN_BUG = "ALREADY_FAILED_BY_KNOWN_BUG";
+
     private boolean ZAFIRA_ENABLED;
     private String ZAFIRA_URL;
     private String ZAFIRA_PROJECT;
@@ -240,7 +243,7 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
             TestCaseType testCase = registerTestCase(adapter);
             
             if(testsWithKnownIssues.contains(testName)) {
-            	throw adapter.getSkipExceptionInstance("ALREADY_FAILED_BY_KNOWN_BUG: " + testName);
+            	throw adapter.getSkipExceptionInstance(ALREADY_FAILED_BY_KNOWN_BUG + ": " + testName);
             }
 
             // Search already registered test!
@@ -249,7 +252,7 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
 
                 // Skip already passed tests if rerun failures enabled
                 if (ZAFIRA_RERUN_FAILURES && !startedTest.isNeedRerun()) {
-                    throw adapter.getSkipExceptionInstance("ALREADY_PASSED: " + testName);
+                    throw adapter.getSkipExceptionInstance(ALREADY_PASSED + ": " + testName);
                 }
 
                 startedTest.setTestCaseId(testCase.getId());
@@ -320,13 +323,13 @@ public class ZafiraEventRegistrar implements TestLifecycleAware {
             return;
         // Test is skipped as ALREADY_PASSED
         if (adapter.getThrowable() != null && adapter.getThrowable().getMessage() != null
-                && adapter.getThrowable().getMessage().startsWith("ALREADY_PASSED")) {
+                && adapter.getThrowable().getMessage().startsWith(ALREADY_PASSED)) {
             return;
         }
 
         // Test is skipped as ALREADY_FAILED_BY_KNOWN_BUG
         if (adapter.getThrowable() != null && adapter.getThrowable().getMessage() != null
-                && adapter.getThrowable().getMessage().startsWith("ALREADY_FAILED_BY_KNOWN_BUG")) {
+                && adapter.getThrowable().getMessage().startsWith(ALREADY_FAILED_BY_KNOWN_BUG)) {
             return;
         }
 

--- a/src/main/java/com/qaprosoft/zafira/listener/service/TestTypeService.java
+++ b/src/main/java/com/qaprosoft/zafira/listener/service/TestTypeService.java
@@ -33,6 +33,8 @@ public interface TestTypeService {
     TestType registerWorkItems(long testId, List<String> workItems);
 
     WorkItem registerKnownIssue(long testId, WorkItem knownIssue);
+    
+    List<WorkItem> getKnownIssues(long testId);
 
     TestType finishTest(TestType test);
 

--- a/src/main/java/com/qaprosoft/zafira/listener/service/impl/TestTypeServiceImpl.java
+++ b/src/main/java/com/qaprosoft/zafira/listener/service/impl/TestTypeServiceImpl.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.listener.service.impl;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -50,6 +51,12 @@ public class TestTypeServiceImpl implements TestTypeService {
     @Override
     public TestType registerWorkItems(long testId, List<String> workItems) {
         return zafiraClient.registerWorkItems(testId, workItems);
+    }
+
+    @Override
+    public List<WorkItem> getKnownIssues(long testId) {
+        HttpClient.Response<WorkItem[]> result = zafiraClient.getTestWorkItems(testId, WorkItem.Type.BUG);
+        return Arrays.asList(result.getObject());
     }
 
     @Override

--- a/src/main/java/com/qaprosoft/zafira/models/db/workitem/BaseWorkItem.java
+++ b/src/main/java/com/qaprosoft/zafira/models/db/workitem/BaseWorkItem.java
@@ -18,10 +18,12 @@ package com.qaprosoft.zafira.models.db.workitem;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.qaprosoft.zafira.models.db.AbstractEntity;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BaseWorkItem extends AbstractEntity {
 

--- a/src/main/java/com/qaprosoft/zafira/models/db/workitem/WorkItem.java
+++ b/src/main/java/com/qaprosoft/zafira/models/db/workitem/WorkItem.java
@@ -18,10 +18,12 @@ package com.qaprosoft.zafira.models.db.workitem;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
 public class WorkItem extends BaseWorkItem {
 


### PR DESCRIPTION
Tests which failed and were marked with Jira's bug by zafira will not be re-run if retry logic is enabled and retry count is > 0.
Instead of this all further executions of this test will be skipped (sending message "ALREADY_FAILED_BY_KNOWN_BUG" in SkipException). Later this exception should be processed by carina AbstractTestListener similarly as it's done for ALREADY_PASSED executions.

This feature will help to seriously reduce execution time for suites which have pretty many tests with known issues and high value of retryCount parameter.